### PR TITLE
docs: publish MkDocs Material site + repo launch readiness

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at afonsobeladiela@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/afondiel/computer-science-notebook/discussions
+    about: Ask questions, share ideas, or start a conversation with the community.

--- a/.github/ISSUE_TEMPLATE/content_fix.md
+++ b/.github/ISSUE_TEMPLATE/content_fix.md
@@ -1,0 +1,15 @@
+---
+name: "📝 Content fix or improvement"
+about: Report a typo, broken link, outdated info, or suggest an improvement to an existing note
+title: "[fix] "
+labels: ["content", "good first issue"]
+---
+
+**Which note?**
+Path or link to the file (e.g. `core/ai-ml/ml-notes/ml-notes.md`):
+
+**What's wrong / could be better?**
+A clear description of the issue (typo, broken link, outdated, unclear, missing detail…):
+
+**Suggested change (optional)**
+What should it say instead?

--- a/.github/ISSUE_TEMPLATE/new_note.md
+++ b/.github/ISSUE_TEMPLATE/new_note.md
@@ -1,0 +1,25 @@
+---
+name: "✨ New note or topic"
+about: Request or propose a new note, topic, or industry application
+title: "[new] "
+labels: ["enhancement", "content"]
+---
+
+**Topic**
+What topic or note should be added?
+
+**Where does it belong?**
+- [ ] `core/` (foundational CS)
+- [ ] `industry/` (applied / domain-specific)
+- [ ] `meta/` (resources, career, tooling)
+
+**Audience level**
+- [ ] Beginner
+- [ ] Intermediate
+- [ ] Advanced
+
+**Why is it useful?**
+Briefly, who benefits and how.
+
+**References (optional)**
+Papers, docs, or links to draw from.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing to the Computer Science Notebook! -->
+
+## What does this PR do?
+A short description of the change.
+
+## Type of change
+- [ ] 📝 New note / content
+- [ ] 🐛 Fix (typo, broken link, correction)
+- [ ] ♻️ Improvement to existing content
+- [ ] 🛠️ Tooling / docs site / project setup
+
+## Checklist
+- [ ] Content follows the structure in [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Links and images resolve correctly
+- [ ] Placed in the correct `core/`, `industry/`, or `meta/` location
+- [ ] Related notes are cross-referenced where relevant
+
+## Related issues
+Closes #

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -r requirements-docs.txt
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ __pycache__/
 Cargo.lock
 
 # ...existing code for project-specific ignores...
+
+# MkDocs build output
+/site/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Cargo.lock
 
 # MkDocs build output
 /site/
+mkdocs.audit.yml

--- a/.nav.yml
+++ b/.nav.yml
@@ -1,0 +1,5 @@
+nav:
+  - Home: README.md
+  - Core: core
+  - Industry: industry
+  - Meta: meta

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,170 @@
-Computer Science Notebook is licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	BY-NC-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses, approved by Creative Commons as essentially the equivalent of this Public License.
+
+     d.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     e.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     f.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     g.	License Elements means the license attributes listed in the name of a Creative Commons Public License. The License Elements of this Public License are Attribution, NonCommercial, and ShareAlike.
+
+     h.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     i.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     j.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     k.	NonCommercial means not primarily intended for or directed towards commercial advantage or monetary compensation. For purposes of this Public License, the exchange of the Licensed Material for other material subject to Copyright and Similar Rights by digital file-sharing or similar means is NonCommercial provided there is no payment of monetary compensation in connection with the exchange.
+
+     l.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     m.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     n.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part, for NonCommercial purposes only; and
+
+               B. produce, reproduce, and Share Adapted Material for NonCommercial purposes only.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+
+               C. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6. No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+     b.	Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties, including when the Licensed Material is used other than for NonCommercial purposes.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i.	identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii.	a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v.	a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+     b.	ShareAlike.In addition to the conditions in Section 3(a), if You Share Adapted Material You produce, the following conditions also apply.
+
+          1. The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-NC-SA Compatible License.
+
+          2. You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
+
+          3. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database for NonCommercial purposes only;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b); and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1.	automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2.	upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     c.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     d.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -9,140 +9,103 @@
   <img src="https://img.shields.io/github/commit-activity/t/afondiel/computer-science-notebook/master" alt="GitHub commit activity (branch)">
   <img src="https://img.shields.io/github/stars/afondiel/computer-science-notebook.svg" alt="GitHub stars">
   <img src="https://img.shields.io/github/forks/afondiel/computer-science-notebook.svg" alt="GitHub forks">
-   <p> <a href="./core/">Core</a> | <a href="./industry/"> Industry</a> | <a href="./meta/">Meta</a> | <a href="https://afondiel.github.io/computer-science-notebook/">Web Doc</a><br>A practical computer science knowledge base</p>
+  <img src="https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="License: CC BY-NC-SA 4.0">
+   <p> <a href="./core/">Core</a> | <a href="./industry/"> Industry</a> | <a href="./meta/">Meta</a> | <a href="https://afondiel.github.io/computer-science-notebook/">📖 Read the Docs</a></p>
 </div>
 
-## 🎯 Overview
+> **700+ free, structured notes** connecting computer science theory to how it's actually used in industry — from algorithms and operating systems to computer vision, LLMs, and edge AI.
 
-The **Computer Science Notebook** is a comprehensive, community-driven knowledge base that bridges the gap between theoretical computer science and its real-world industry applications.
+## 🎯 What is this?
 
-Whether you're a student learning the fundamentals, a professional looking to switch industries, or an experienced developer exploring new domains, this notebook is your companion.
+The **Computer Science Notebook** is an open, community-driven knowledge base that bridges the gap between **theoretical computer science** and **real-world industry applications**.
 
-## 📚 Project Structure
+Whether you're a student learning fundamentals, a professional switching domains, or an engineer exploring a new field, this notebook is a practical companion — organized, tiered by skill level, and cross-referenced from theory to practice.
 
-```
-computer-science-notebook/
-├── core/                    # Core CS Topics
-│   ├── programming/         # Languages, patterns, practices
-│   ├── systems/             # OS, embedded, cloud
-│   ├── ai-ml/               # AI, ML, computer vision
-│   └── engineering/         # Architecture, testing, DevOps
-├── industry/                # Industry Applications
-│   ├── automotive/          # Electric vehicles, safety systems
-│   ├── agriculture/         # Smart farming, IoT
-│   └── aerospace/           # Navigation, control systems
-└── meta/                    # Project Resources
-    ├── docs/                # Contributing guidelines
-    └── resources/           # Books, courses, interviews
-```
+- 📚 **700+ notes** across AI/ML, programming, systems, engineering, and fundamentals
+- 🏭 **Industry sections** mapping concepts to automotive, aerospace, healthcare, manufacturing, and more
+- 🎚️ **Tiered content** — most topics split into beginner → intermediate → advanced
+- 🔎 **Searchable docs site** built with MkDocs Material — [browse it here](https://afondiel.github.io/computer-science-notebook/)
 
-## 🌟 Key Features
+## 🚀 Start Here
 
-### For Students & Learners
-- **Core CS Fundamentals**: Comprehensive coverage of essential computer science topics
-- **Practical Examples**: Real code samples and implementations
-- **Learning Paths**: Structured guidance from basics to advanced topics
-- **Interview Prep**: Curated resources for technical interviews
+| I want to… | Go to |
+|---|---|
+| Learn **AI / Machine Learning** | [core/ai-ml](core/ai-ml/) |
+| Master a **programming language** | [core/programming/languages](core/programming/languages/) |
+| Understand **systems & infrastructure** | [core/systems](core/systems/) |
+| Level up **software engineering** | [core/engineering](core/engineering/) |
+| See CS applied in **industry** | [industry](industry/) |
+| Prep for **technical interviews** | [meta/career/job-interview-notes](meta/career/job-interview-notes/) |
 
-### For Industry Professionals
-- **Industry Applications**: Real-world implementations across different sectors
-- **Case Studies**: Detailed analysis of industry-specific solutions
-- **Best Practices**: Industry-standard approaches and methodologies
-- **Cross-Domain Knowledge**: Learn how concepts apply across different industries
+## 🗂️ Explore the Notebook
 
-## 🚀 Getting Started
+### 🤖 AI & Machine Learning — *the most developed section*
+- [Machine Learning](core/ai-ml/ml-notes/) · [Deep Learning](core/ai-ml/deep-learning-notes/) · [Computer Vision](core/ai-ml/computer-vision-notes/)
+- [NLP](core/ai-ml/nlp-notes/) · [Generative AI](core/ai-ml/generative-ai-notes/) · [Prompt Engineering](core/ai-ml/prompt-engineering-notes/)
+- [AI Agents](core/ai-ml/ai-agents-notes/) · [Computer Audition](core/ai-ml/computer-audition/) · [Cognitive Science](core/ai-ml/cognitive-science/)
 
-### Online Access
+### 💻 Programming
+- [Languages](core/programming/languages/) (C, C++, Python, Rust, Go, Java, MATLAB…)
+- [Algorithms](core/programming/algorithms/) · [Data Structures](core/programming/data-structures/) · [Design Patterns](core/programming/design-patterns-notes/)
+- [High-Performance Programming](core/programming/high-perf-programming/) · [Parallel Programming](core/programming/parallel-programming/)
 
-Read the notebook Visit our documentation at: https://afondiel.github.io/computer-science-notebook/
+### 🖥️ Systems
+- [Operating Systems](core/systems/operating-systems/) · [Embedded Systems](core/systems/embedded-systems/) · [Edge Computing](core/systems/edge-computing/)
+- [Cloud Computing](core/systems/cloud-computing/) · [IoT](core/systems/iot/) · [Quantum Computing](core/systems/quantum-computing/)
 
-### Local Setup
+### 🏗️ Engineering
+- [Software Architecture](core/engineering/sw-architecture-design/) · [Testing](core/engineering/sw-testing/) · [DevOps](core/engineering/devops-notes/)
+- [Web](core/engineering/web/) · [Game Dev](core/engineering/gamedev-notes/) · [Version Control](core/engineering/vcs/)
+
+### 🔬 Fundamentals
+- [Signal Processing](core/fundamentals/signal-processing/) · [Computer Graphics](core/fundamentals/computer-graphics/) · [Control Systems](core/fundamentals/control-systems/)
+
+### 🏭 Industry Applications
+- [Transportation & Automotive](industry/transportation/) · [Aerospace](industry/aerospace/) · [Healthcare](industry/healthcare/)
+- [Manufacturing](industry/manufacturing/) · [Agriculture](industry/agriculture/) · [Robotics](industry/robotics/) · [Smart City](industry/smart-city/)
+
+## 📖 Read Online
+
+The notebook is published as a searchable documentation site:
+
+**➡️ https://afondiel.github.io/computer-science-notebook/**
+
+### Build the docs locally
 ```bash
 # Clone the repository
 git clone https://github.com/afondiel/computer-science-notebook
-
-# Navigate to the project
 cd computer-science-notebook
 
-# Install mdbook (requires Rust)
-cargo install mdbook
+# Install the docs toolchain
+pip install -r requirements-docs.txt
 
-# Build and serve locally
-mdbook build
-mdbook serve
+# Serve locally with live reload
+mkdocs serve
 ```
-
-## 🔍 Finding What You Need
-
-1. **Learning Core CS**:
-   - Start with `/core` for fundamental topics
-   - Each topic includes theory, examples, and practical applications
-
-2. **Industry Applications**:
-   - Browse `/industry` for sector-specific implementations
-   - Find real-world applications of CS concepts in different domains
-
-3. **Resources & Meta**:
-   - Check `/meta` for learning resources and project documentation
-   - Find interview preparation materials and study guides
 
 ## 🤝 Contributing
 
-We welcome contributions from everyone! Here's how you can help:
+Contributions are welcome — add a note, fix a link, improve an explanation, or share an industry case study. Good first contributions are labeled in [Issues](https://github.com/afondiel/computer-science-notebook/issues).
 
-1. **Add Core Content**:
-   - Enhance existing CS topics
-   - Add new theoretical concepts
-   - Contribute code examples
-
-2. **Share Industry Experience**:
-   - Add case studies from your industry
-   - Document real-world applications
-   - Share industry-specific best practices
-
-3. **Improve Resources**:
-   - Add learning materials
-   - Create or enhance documentation
-   - Share interview experiences
-
-See our [Contributing Guide](CONTRIBUTING.md) for detailed instructions.
+See the [Contributing Guide](CONTRIBUTING.md) for templates and conventions.
 
 ## 🛣️ Roadmap
 
-1. **Content Enhancement**:
-   - Expanding industry coverage
-   - Adding interactive examples
-   - Creating comprehensive learning paths
-
-2. **Technical Features**:
-   - Add LLM-API for real-time note generation
-      - Leverage HF/spaces + Gradio  as API endpoints + external UI
-      - Users should choose/select the model they want to use based on the available models   
-   - Interactive code examples
-   - Improved search and navigation
-
-3. **Community Growth**:
-   - Industry expert contributions
-   - Peer review system
-   - Community discussions
+- **Content**: expand industry coverage, add interactive examples and learning paths
+- **Platform**: searchable docs site (✅ live), improved navigation and tags
+- **Community**: expert contributions, peer review, discussions
 
 ## 📄 License
 
-This project is licensed under Attribution-NonCommercial-ShareAlike 4.0 International see the [LICENSE](LICENSE) file for details.
+Licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](LICENSE) (CC BY-NC-SA 4.0).
 
 ## ⭐ Support the Project
 
-If you find this notebook helpful:
-- Star the repository
-- Share it with others
-- Contribute your knowledge
-- Report issues or suggest improvements
-
-## 🙏 Acknowledgments
-
-Special thanks to all contributors who have helped make this knowledge base possible. Together, we're making computer science education more accessible to everyone.
-
----
+If you find this helpful:
+- **Star** the repository ⭐
+- **Share** it with students and colleagues
+- **Contribute** a note or fix
+- **Report** issues or suggest improvements
 
 ## Star History
 
@@ -151,6 +114,5 @@ Special thanks to all contributors who have helped make this knowledge base poss
 ---
 > As a lifelong learner and advocate for accessible education, I hope this project helps you in your journey. Feel free to reach out with questions or suggestions!
 >
-> Cheers,  
->[@Muntu](https://github.com/afondiel)
->
+> Cheers,
+> [@Muntu](https://github.com/afondiel)

--- a/core/ai-ml/agi-notes/readme.md
+++ b/core/ai-ml/agi-notes/readme.md
@@ -10,7 +10,7 @@
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 
 > ## "There's a big difference between knowing the name of something and knowing something" - Richard Feynman

--- a/core/ai-ml/ai-agents-notes/ai-agents-notes.md
+++ b/core/ai-ml/ai-agents-notes/ai-agents-notes.md
@@ -23,7 +23,7 @@
 - [References](#references)
 
 ---
-- Related Notes: [AI Notes](../ai-notes.md), [Embodied-AI Notes](./core/ai-ml/ai-agents-notes/embodied-agents-notes.md), [Robotics Notes](../../robotics/robotics-notes.md), 
+- Related Notes: [AI Notes](../ai-notes.md), [Embodied-AI Notes](./embodied-agents-notes.md), [Robotics Notes](../../robotics/robotics-notes.md), 
 
 ## Introduction
 **Autonomous agents** are systems or software entities that perform tasks or make decisions independently, often in dynamic environments, without continuous human intervention.

--- a/core/ai-ml/ai-agents-notes/embodied-agents-notes.md
+++ b/core/ai-ml/ai-agents-notes/embodied-agents-notes.md
@@ -19,7 +19,7 @@
 - [References](#references)
 
 ---
-- Related Notes: [AI Notes](../ai-notes.md), [Embodied-AI Notes](./core/ai-ml/ai-agents-notes/embodied-agents-notes.md), [AI Agents](../ai-agents-notes/ai-agents-notes.md), [Robotics Notes](../../robotics/robotics-notes.md)
+- Related Notes: [AI Notes](../ai-notes.md), [Embodied-AI Notes](./embodied-agents-notes.md), [AI Agents](../ai-agents-notes/ai-agents-notes.md), [Robotics Notes](../../robotics/robotics-notes.md)
 
 ## Introduction
 **Embodied agents** are autonomous systems or entities equipped with physical bodies, enabling them to interact with the physical world through sensors and actuators, mimicking human-like behavior and perception.

--- a/core/ai-ml/deep-learning-notes/readme.md
+++ b/core/ai-ml/deep-learning-notes/readme.md
@@ -8,6 +8,6 @@ This is a Deep Learning Hello World resources.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ### “You're nothing but a pack of neurons.” — Francis Crick

--- a/core/ai-ml/generative-ai-notes/readme.md
+++ b/core/ai-ml/generative-ai-notes/readme.md
@@ -9,7 +9,7 @@ This is a Hello World resources for Generative AI (GenAI).
 
 ## Contributing
 
-Please refer to this [file](../../CONTRIBUTING.md).
+Please refer to this [file](../../../CONTRIBUTING.md).
 
 
 > ### "Generative AI is to Artificial Intelligence what Big Bang once was for the universe, the birth of galaxies, lives and human intelligence." ~ [@muntu](https://github.com/afondiel)

--- a/core/ai-ml/ml-notes/readme.md
+++ b/core/ai-ml/ml-notes/readme.md
@@ -11,7 +11,7 @@ This is a "Hello World" resources for Machine Learning (ML).
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ### “The machines do not solve problems with greater insight than men do, only faster. Only faster!” — Isaac Asimov
 

--- a/core/ai-ml/nlp-notes/readme.md
+++ b/core/ai-ml/nlp-notes/readme.md
@@ -7,7 +7,7 @@ This is a "Hello World" resources for Natural Language Processing (NLP).
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ### “If you talk to a man in a language he understands, that goes to his head. If you talk to him in his language, that goes to his heart.”
 > ### — Nelson Mandela

--- a/core/ai-ml/prompt-engineering-notes/readme.md
+++ b/core/ai-ml/prompt-engineering-notes/readme.md
@@ -9,6 +9,6 @@ Credits to : Max Rascher
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > **"...And so my hope is someday when the next Aristotle is alive, we can capture the underlying worldview of that Aristotle, in a computer, and someday some students will be able to not only read the words Aristotle wrote but ask Aristotle a question and get an answer."** - Steve Jobs (Generative AI Prediction from 1985 Speech)

--- a/core/ai-ml/readme.md
+++ b/core/ai-ml/readme.md
@@ -10,7 +10,7 @@ AI notes & resources.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
 
 
 > ### "In a properly automated and educated world, then, machines may prove to be the true humanizing influence. It may be that machines will do the work that makes life possible and that human beings will do all the other things that make life pleasant and worthwhile" 

--- a/core/engineering/devops-notes/readme.md
+++ b/core/engineering/devops-notes/readme.md
@@ -6,5 +6,5 @@ This is a "Hello World" resources for DevOps.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 

--- a/core/engineering/gamedev-notes/readme.md
+++ b/core/engineering/gamedev-notes/readme.md
@@ -6,5 +6,5 @@ This is a game development "Hello World" resources.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 

--- a/core/engineering/sw-architecture-design/readme.md
+++ b/core/engineering/sw-architecture-design/readme.md
@@ -6,7 +6,7 @@ Hello World for Software Architecture Design (SAD) Notes.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ## “If you think good architecture is expensive, try bad architecture.” — Brian Foote and Joseph Yoder
 

--- a/core/engineering/sw-documentation-convention/CODING_CONVENTIONS_C++.md
+++ b/core/engineering/sw-documentation-convention/CODING_CONVENTIONS_C++.md
@@ -5,8 +5,8 @@ When contributing source code, please adhere to the following coding style,
 which is loosely based on the [Google C++ Style Guide] and the coding
  conventions used by the C++ Standard Library. Based on the [CAF coding style].
 
-[Google C++ Style Guide]: (https://google.github.io/styleguide/cppguide.html)
-[CAF coding style]: (https://github.com/actor-framework/actor-framework/blob/master/CONTRIBUTING.md)
+[Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html
+[CAF coding style]: https://github.com/actor-framework/actor-framework/blob/master/CONTRIBUTING.md
 
 ## Example for the Impatient
 

--- a/core/engineering/sw-testing/readme.md
+++ b/core/engineering/sw-testing/readme.md
@@ -10,6 +10,6 @@ This is a "Hello World" resources for **sw testing**.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 

--- a/core/engineering/web/readme.md
+++ b/core/engineering/web/readme.md
@@ -9,7 +9,7 @@ This is a Hello World resources for web development.
 
 ## Contributing
 
-Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md).
+Please refer to the [CONTRIBUTING.md](../../../CONTRIBUTING.md).
 
 > ## “In the information age, man and spider both live in a web.” ― Amit Kalantri
 

--- a/core/fundamentals/control-systems/readme.md
+++ b/core/fundamentals/control-systems/readme.md
@@ -6,5 +6,5 @@ This is a Control Law "Hello World" resources.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 

--- a/core/fundamentals/nanotechnology/readme.md
+++ b/core/fundamentals/nanotechnology/readme.md
@@ -6,4 +6,4 @@ This is a "Hello World" resources for Computer Science concepts applied in [Nano
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.

--- a/core/programming/design-patterns-notes/readme.md
+++ b/core/programming/design-patterns-notes/readme.md
@@ -7,7 +7,7 @@ This is Design Patterns "Hello World" resources
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 
 

--- a/core/programming/high-perf-programming/readme.md
+++ b/core/programming/high-perf-programming/readme.md
@@ -28,7 +28,7 @@ core/programming/high-Perf/
  
 ## Contributing
 
-Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to the [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 
 

--- a/core/programming/languages/lua-notes/readme.md
+++ b/core/programming/languages/lua-notes/readme.md
@@ -6,5 +6,5 @@ This is a Lua programming language "Hello World" resources.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../../CONTRIBUTING.md) file.
 

--- a/core/programming/languages/matlab-notes/matlab-notes.md
+++ b/core/programming/languages/matlab-notes/matlab-notes.md
@@ -40,7 +40,7 @@ Hello, world!
 ```
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../../CONTRIBUTING.md) file.
 
 
 ## References

--- a/core/programming/languages/r-notes/readme.md
+++ b/core/programming/languages/r-notes/readme.md
@@ -6,5 +6,5 @@ This is a game development "Hello World" resources.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../../CONTRIBUTING.md) file.
 

--- a/core/programming/languages/rust-notes/readme.md
+++ b/core/programming/languages/rust-notes/readme.md
@@ -39,7 +39,7 @@ cargo run
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+Please refer to this [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 
 > [!TIP] 

--- a/core/programming/regex-notes/readme.md
+++ b/core/programming/regex-notes/readme.md
@@ -1,6 +1,6 @@
 # REGULAR EXPRESSION (RegEx) - Notes
 
-![](.\Best-Regular-Expressions-Cheat-Sheet-01.jpg)
+![](./Best-Regular-Expressions-Cheat-Sheet-01.jpg)
 
 ## Overview
 
@@ -8,7 +8,7 @@ This is RegeX "Hello World" resources.
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 
 ## References

--- a/core/systems/cloud-computing/readme.md
+++ b/core/systems/cloud-computing/readme.md
@@ -30,5 +30,5 @@ Cloud Computing core concepts for real-world applications.
 
 ## Contributing
 
-Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to the [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 

--- a/core/systems/edge-computing/edge-ai/concepts/on-device-ai-notes.md
+++ b/core/systems/edge-computing/edge-ai/concepts/on-device-ai-notes.md
@@ -129,7 +129,7 @@ with open('model.tflite', 'wb') as f:
 
 ## Continuous Learning Strategy
 - **Next Steps**: Explore federated learning for on-device training; investigate device-specific model optimizations.
-- **Related Topics**: [Embedded AI](../embedded-ai-notes.md), [Model Compression](./model-compression-notes.md), [IoT Security](../../../edge-iot-notes/iot/iot-notes.md).
+- **Related Topics**: [Embedded AI](../../../embedded-systems/embedded-ai-notes/embedded-ai-notes.md), [Model Compression](./model-compression-notes.md), [IoT Security](../../../iot/iot-notes.md).
 
 ## References
 - **Harvard TinyML Course**: [Link to course](https://www.edx.org/course/tiny-machine-learning)

--- a/core/systems/edge-computing/edge-ai/readme.md
+++ b/core/systems/edge-computing/edge-ai/readme.md
@@ -36,5 +36,5 @@ Edge-AI core concepts for real-world applications.
 
 ## Contributing
 
-Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to the [CONTRIBUTING.md](../../../../CONTRIBUTING.md) file.
 

--- a/core/systems/edge-computing/edge-computing-notes.md
+++ b/core/systems/edge-computing/edge-computing-notes.md
@@ -111,5 +111,5 @@ Books:
 
 ## Related Sources
 
-- [Embedded AI](../embedded-ai-notes/tinyML/tinyML-notes.md)
+- [Embedded AI](../embedded-systems/embedded-ai-notes/tinyML/tinyML-notes.md)
 

--- a/core/systems/edge-computing/readme.md
+++ b/core/systems/edge-computing/readme.md
@@ -11,6 +11,6 @@ Edge AI, Computing and IoT: Connecting the Physical and Digital World.
 
 ## Contributing
 
-Please refer to this [file](../../CONTRIBUTING.md).
+Please refer to this [file](../../../CONTRIBUTING.md).
 
 

--- a/core/systems/embedded-systems/embedded-ai-notes/tinyML/readme.md
+++ b/core/systems/embedded-systems/embedded-ai-notes/tinyML/readme.md
@@ -8,7 +8,7 @@ TinyML "Hello World" resources
 
 ## Contributing
 
-Please refer to this [file](../../CONTRIBUTING.md).
+Please refer to this [file](../../../../../CONTRIBUTING.md).
 
 ## References
 

--- a/core/systems/embedded-systems/readme.md
+++ b/core/systems/embedded-systems/readme.md
@@ -10,6 +10,6 @@ Embedded Systems and AI: Intelligent Applications in Embedded Environments.
 
 ## Contributing
 
-Please refer to this [file](../CONTRIBUTING.md).
+Please refer to this [file](../../../CONTRIBUTING.md).
 
 > ### "We are embedded in a biological world and related to the organisms around us. ~ Walter Gilbert"

--- a/core/systems/operating-systems/readme.md
+++ b/core/systems/operating-systems/readme.md
@@ -7,7 +7,7 @@ This is a Hello World resources for Operating System (OS).
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](..\CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ## "I'm doing a (free) operating system (just a hobby, won't be big and professional like gnu) for 386(486) AT clones" - [Linus Torvalds, August 25, 1991](https://github.com/torvalds) 
 

--- a/core/systems/quantum-computing/readme.md
+++ b/core/systems/quantum-computing/readme.md
@@ -6,7 +6,7 @@ This is a Quantum Computing "Hello World" resources.
 
 ## Contributing 
 
-Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file to check the guidelines.
+Please refer to the [CONTRIBUTING.md](../../../CONTRIBUTING.md) file to check the guidelines.
 
 
 > ### "If you think you understand quantum mechanics, you don't understand quantum mechanics"

--- a/industry/agriculture/readme.md
+++ b/industry/agriculture/readme.md
@@ -9,7 +9,7 @@ This is a set of tools and resources for sw, ai and IoT Enginneers and makers wh
 
 ## Contributing
 
-If you plan to add more resources in this note, please refer to [CONTRIBUTING.md](..\CONTRIBUTING.md) file.
+If you plan to add more resources in this note, please refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
 
 
 

--- a/industry/healthcare/readme.md
+++ b/industry/healthcare/readme.md
@@ -6,6 +6,6 @@ This is a "Hello World" resources for Computer Science concepts applied in [Heal
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
 
 ### > "Life is an equilibrium state between synthesis and degradation of proteins." ~ Yoshinori Ohsumi

--- a/industry/transportation/automotive/readme.md
+++ b/industry/transportation/automotive/readme.md
@@ -9,7 +9,7 @@ This is a computer science notes and resources for Automotive Industry.
 
 ## Contributing 
 
-Please refer to this [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to this [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 
 > ## "The only progress is to keep moving forward." - Henry Ford
 

--- a/industry/transportation/automotive/safety/safety-notes.md
+++ b/industry/transportation/automotive/safety/safety-notes.md
@@ -40,7 +40,7 @@ Automotive safety functions classification based on [ISO26262](https://en.wikipe
 
 ## Contributing
 
-Please refer to this [CONTRIBUTING.md](../../CONTRIBUTING.md).
+Please refer to this [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 ## References 
 

--- a/industry/transportation/automotive/self-driving/readme.md
+++ b/industry/transportation/automotive/self-driving/readme.md
@@ -6,7 +6,7 @@ This is a "Hello World" resources for Self-Driving Cars.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../../CONTRIBUTING.md) file.
 
 
 ## ADAS & Self-Driving "War"

--- a/meta/career/job-interview-notes/job-interview-prep.md
+++ b/meta/career/job-interview-notes/job-interview-prep.md
@@ -35,7 +35,7 @@ Pre-Interview Research:
 
 - [LeetCode](https://leetcode.com/)
 - [codewars](https://www.codewars.com/)
-- [replit](replit.com)
+- [replit](https://replit.com)
 - [Codecademy](https://www.codecademy.com/)
 - [Codigame (France)](https://www.codingame.com/)
 - [hackerrank](https://www.hackerrank.com/)

--- a/meta/career/job-interview-notes/readme.md
+++ b/meta/career/job-interview-notes/readme.md
@@ -6,5 +6,5 @@ Software Engineering job interview resources.
 
 ## Contributing
 
-Please refer to [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+Please refer to [CONTRIBUTING.md](../../../CONTRIBUTING.md) file.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,100 @@
+site_name: Computer Science Notebook
+site_description: A community-driven knowledge base bridging computer science theory with real-world industry applications.
+site_url: https://afondiel.github.io/computer-science-notebook/
+site_author: Afonso Diela
+repo_url: https://github.com/afondiel/computer-science-notebook
+repo_name: afondiel/computer-science-notebook
+edit_uri: edit/master/
+docs_dir: .
+use_directory_urls: false
+copyright: Copyright &copy; Afonso Diela — CC BY-NC-SA 4.0
+
+theme:
+  name: material
+  logo: meta/tools/logo-new.png
+  favicon: meta/tools/logo-new.png
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.top
+    - navigation.indexes
+    - navigation.footer
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.action.edit
+    - content.tooltips
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - same-dir
+  - search
+  - awesome-nav
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+      fallback_to_build_date: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/afondiel/computer-science-notebook
+  generator: false
+
+# docs_dir is the repo root (via the same-dir plugin). These paths are excluded
+# from the built site.
+exclude_docs: |
+  .github/
+  .gitignore
+  CLAUDE.md
+  MKDOCS_MIGRATION_PLAN.md
+  requirements-docs.txt
+  meta/templates/
+  meta/tools/assistant/
+  **/node_modules/

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+mkdocs-material==9.7.6
+mkdocs-same-dir==0.1.5
+mkdocs-awesome-nav==3.3.0
+mkdocs-git-revision-date-localized-plugin==1.5.3
+pymdown-extensions==11.0.1


### PR DESCRIPTION
## Summary

Publishes the notebook as a polished, searchable **MkDocs Material** documentation site with automated GitHub Pages deployment, and brings the repo up to launch standard (README, license detection, community health files).

Part of the growth plan to make the repo worth starring on first click.

## What's included

### 📖 Docs site (MkDocs Material)
- Full site builds from the entire `core/` + `industry/` + `meta/` tree **in place** (`docs_dir: .` via the `same-dir` plugin) — no content duplication.
- Auto-generated navigation from the folder structure (`awesome-nav`), so new notes appear in the nav automatically.
- Material theme: light/dark toggle, instant navigation, built-in search, code copy, per-page "edit on GitHub" links, git revision dates, mermaid, admonitions, tabbed content.
- **723 pages** build successfully.
- `use_directory_urls: false` — required because the repo mixes code files and notes with colliding names (e.g. `notes.c` + `notes.c.md`); this eliminates a whole class of build collisions.

### 🚀 CI/CD
- `.github/workflows/docs.yml` builds and deploys to **GitHub Pages via Actions artifact** on push to `master`. (Pages source is set to "GitHub Actions" in repo settings.)
- `requirements-docs.txt` pins the docs toolchain for reproducible builds.

### 🔗 Content link fixes
- Fixed **43 broken internal links** (57 → 14): corrected `CONTRIBUTING.md` relative depths across 34 readme files, Windows-style backslash paths, doubled path prefixes, a bare `replit.com` link, and malformed reference-style links.
- The remaining **14 warnings are genuine content gaps** — links to notes/images that don't exist in the repo yet. These are documented as good-first-issue candidates rather than fabricated.

### 📄 License detection
- Replaced the one-line `LICENSE` stub with the **full official CC BY-NC-SA 4.0 legal text** (fetched from SPDX) so GitHub detects it as `CC-BY-NC-SA-4.0` instead of "Other". **Terms are unchanged.**

### 🧱 Repo readiness
- Rewrote `README.md` as a proper landing page (elevator pitch, "start here" table, curated topic index, live-docs link) — doubles as the site homepage.
- Added community health files: `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), issue templates (content fix / new note), and a PR template.

## Testing
- `mkdocs build` completes cleanly: 723 pages, 0 errors, 14 known content-gap warnings.
- Verified homepage, topic pages, dark mode, and search render correctly (screenshots shared with maintainer).

## Notes for the maintainer
- CoC enforcement contact is set to the account email — swap it if you prefer a different contact.
- After merge: confirm the site is live at https://afondiel.github.io/computer-science-notebook/ and that the sidebar shows "CC BY-NC-SA 4.0".
- A launch kit (Show HN / Reddit / X / awesome-lists copy) and a good-first-issues seed list were prepared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016HU1S5PfpeM8n3gK3yfNk4)_